### PR TITLE
the Composer autoloader does not find the "vendor" dir under the "lib". ...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "homepage": "https://github.com/authy/authy-php",
     "license": "MIT",
     "require": {
+	"resty/resty": "dev-master"
     },
     "require-dev": {
         "EHER/PHPUnit": ">= 1.6"


### PR DESCRIPTION
...You need to require the Resty libs too
