### PR TITLE
updated composer package reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Include it in your `composer.json` as follows:
 
 	{
 	    "require": {
-	        "authy/php": "*"
+	        "authy/php": "dev-master"
 	    }
 	}
 


### PR DESCRIPTION
Newer versions of `composer` do not allow asterisks (`*`) when installing development packages. More info [here](https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion).
