### PR TITLE
Reformat legacy code in favour of guzzle

### DIFF
--- a/lib/Authy/AuthyApi.php
+++ b/lib/Authy/AuthyApi.php
@@ -150,16 +150,14 @@ class AuthyApi
     }
 
     /**
-     * @param string $authy_id User's id stored in your database
      * @param string $uuid     Unique identifier of approval request
      * @param array  $opts     Array of options
      *
      * @return AuthyResponse
      */
-    public function checkOneTouchApproval($authy_id, $uuid, $opts = [])
+    public function checkOneTouchApproval($uuid, $opts = [])
     {
-        $authy_id = urlencode($authy_id);
-        $resp = $this->rest->get("onetouch/json/users/{$authy_id}/approval_requests/{$uuid}", array_merge(
+        $resp = $this->rest->get("onetouch/json/approval_requests/{$uuid}", array_merge(
             $this->default_options,
             ['query' => $opts]
         ));

--- a/lib/Authy/AuthyResponse.php
+++ b/lib/Authy/AuthyResponse.php
@@ -23,35 +23,29 @@
  */
 namespace Authy;
 
+use Psr\Http\Message\ResponseInterface;
+
 class AuthyResponse
 {
-    protected $raw_response;
-    protected $body;
-    protected $errors;
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var array
+     */
+    private $body;
 
     /**
      * Constructor.
      *
-     * @param array $raw_response Raw server response
+     * @param ResponseInterface $response Raw server response
      */
-    public function __construct($raw_response)
+    public function __construct(ResponseInterface $response)
     {
-        $this->raw_response = $raw_response;
-        $this->body = (! isset($raw_response->body)) ? json_decode($raw_response->getBody()) : $raw_response->body;;
-        $this->errors = new \stdClass();
-
-        // Handle errors
-        if (isset($this->body->errors)) {
-            $this->errors = $this->body->errors; // when response is {errors: {}}
-            unset($this->body->errors);
-        } elseif ($raw_response->getStatusCode() == 400) {
-            $this->errors = $this->body; // body here is a stdClass
-            $this->body = new \stdClass();
-        } elseif (!$this->ok() && gettype($this->body) == 'string') {
-            // the response was an error so put the body as an error
-            $this->errors = (object) array("error" => $this->body);
-            $this->body = new \stdClass();
-        }
+        $this->response = $response;
+        $this->body = json_decode((string)$this->response->getBody(), true);
     }
 
     /**
@@ -61,7 +55,7 @@ class AuthyResponse
      */
     public function ok()
     {
-        return $this->raw_response->getStatusCode() == 200;
+        return $this->response->getStatusCode() === 200;
     }
 
     /**
@@ -71,31 +65,42 @@ class AuthyResponse
      */
     public function id()
     {
-        return isset($this->body->id) ? $this->body->id : null;
+        return isset($this->body['user']) && isset($this->body['user']['id']) ? $this->body['user']['id'] : null;
     }
 
     /**
      * Get the request errors
      *
-     * @return stdClass object containing the request errors
+     * @return \stdClass containing the request errors
      */
     public function errors()
     {
-        return $this->errors;
+        $errors = new \stdClass();
+
+        if (!$this->ok()) {
+            foreach ($this->body['errors'] as $key => $value) {
+                $errors->$key = $value;
+            }
+        }
+
+        return $errors;
     }
 
+    /**
+     * @return string
+     */
     public function message()
     {
-        return $this->body->message;
+        return (string)$this->response->getBody();
     }
 
     /**
      * Returns the variable specified in the response if present
      *
-     * @return value
+     * @return mixed
      */
     public function bodyvar($var)
     {
-        return isset($this->body->$var) ? $this->body->$var: null;
+        return isset($this->body[$var]) ? $this->body[$var]: null;
     }
 }

--- a/lib/Authy/AuthyUser.php
+++ b/lib/Authy/AuthyUser.php
@@ -13,7 +13,7 @@
  */
 
 /**
- * User implementation. Extends from Authy_Response
+ * User implementation. Extends from Authy_response
  *
  * @category Services
  * @package  Authy
@@ -23,22 +23,17 @@
  */
 namespace Authy;
 
+use Psr\Http\Message\responseInterface;
+
 class AuthyUser extends AuthyResponse
 {
     /**
      * Constructor.
      *
-     * @param array $raw_response Raw server response
+     * @param ResponseInterface $response server response
      */
-    public function __construct($raw_response)
+    public function __construct(ResponseInterface $response)
     {
-        $body = json_decode($raw_response->getBody());
-
-        if (isset($body->user)) {
-            // response is {user: {id: id}}
-            $raw_response->body = $body->user;
-        }
-
-        parent::__construct($raw_response);
+        parent::__construct($response);
     }
 }

--- a/lib/Authy/AuthyUser.php
+++ b/lib/Authy/AuthyUser.php
@@ -23,7 +23,7 @@
  */
 namespace Authy;
 
-use Psr\Http\Message\responseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class AuthyUser extends AuthyResponse
 {

--- a/tests/Authy/ApiTest.php
+++ b/tests/Authy/ApiTest.php
@@ -163,6 +163,66 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         //$this->assertEquals("is not activated for this account", $sms->errors()->enable_sms);
     }
 
+    public function testRequestOneTouchApprovalWithInvalidUser()
+    {
+        $mock_client = $this->mockClient([[404, '{"errors": {"message": "User not found."}}']]);
+        $oneTouchApproval = $mock_client->requestOneTouchApproval(0);
+
+        $this->assertEquals(false, $oneTouchApproval->ok());
+        $this->assertEquals("User not found.", $oneTouchApproval->errors()->message);
+    }
+
+    public function testRequestOneTouchApprovalWithValidUser()
+    {
+        $mock_client = $this->mockClient([
+            [200, '{ "user": { "id": 2 } }'],
+            [200, '{ "approval_request": { "uuid":"fd285c30-97f8-0135-cfa7-1241e5695bb0" }, "success": true }'],
+        ]);
+
+        $user = $mock_client->registerUser('user@example.com', '305-456-2345', 1);
+        $oneTouchApproval = $mock_client->requestOneTouchApproval($user->id());
+
+        $this->assertEquals(true, $oneTouchApproval->ok());
+        $this->assertEquals(
+            "{ \"approval_request\": { \"uuid\":\"fd285c30-97f8-0135-cfa7-1241e5695bb0\" }, \"success\": true }",
+            $oneTouchApproval->message()
+        );
+    }
+
+    public function testCheckOneTouchApprovalWithInvalidUuid()
+    {
+        $mock_client = $this->mockClient([
+            [200, '{ "user": { "id": 2 } }'],
+            [404, '{ "message": "Approval request not found: 1231", "success": false, }'],
+        ]);
+
+        $user = $mock_client->registerUser('user@example.com', '305-456-2345', 1);
+        $oneTouchApproval = $mock_client->checkOneTouchApproval($user->id(), '1231');
+
+        $this->assertEquals(false, $oneTouchApproval->ok());
+        $this->assertEquals(
+            "{ \"message\": \"Approval request not found: 1231\", \"success\": false, }",
+            $oneTouchApproval->message()
+        );
+    }
+
+    public function testCheckOneTouchApprovalWithValidUuid()
+    {
+        $mock_client = $this->mockClient([
+            [200, '{ "user": { "id": 2 } }'],
+            [200, '{ "approval_request": { "uuid":"fd285c30-97f8-0135-cfa7-1241e5695bb0" }, "success": true }'],
+        ]);
+
+        $user = $mock_client->registerUser('user@example.com', '305-456-2345', 1);
+        $oneTouchApproval = $mock_client->checkOneTouchApproval($user->id(), 'fd285c30-97f8-0135-cfa7-1241e5695bb0');
+
+        $this->assertEquals(true, $oneTouchApproval->ok());
+        $this->assertEquals(
+            "{ \"approval_request\": { \"uuid\":\"fd285c30-97f8-0135-cfa7-1241e5695bb0\" }, \"success\": true }",
+            $oneTouchApproval->message()
+        );
+    }
+
     public function testPhonceCallWithInvalidUser()
     {
         $mock_client = $this->mockClient([[404, '{"errors": {"message": "User not found."}}']]);


### PR DESCRIPTION
I've found there are a lot of messy code as a residue after Resty library, which was used in your project. I've updated both AuthyResponse and AuthyUser classes in favor of guzzle HTTP library.

Changes:
- added ResponseInterface type to AuthyResponse and AuthyUser constructor
- removed an old $raw_response property (related to Resty)
- updated all methods due to get data from an object which implements ResponseInterface

Tests: 
- no changes
- all tests passed 