### PR TITLE
verifyToken remove unsetting "force" option

### DIFF
--- a/lib/Authy/AuthyApi.php
+++ b/lib/Authy/AuthyApi.php
@@ -96,8 +96,6 @@ class AuthyApi
     {
         if (! array_key_exists("force", $opts)) {
             $opts["force"] = "true";
-        } else {
-            unset($opts["force"]);
         }
 
         $token = urlencode($token);


### PR DESCRIPTION
The previous code says to delete the `force` option when it's present. It will make that option useless and forcing all request to force => true if omitted by default.