### PR TITLE
Adding the ability pass a custom message with phone verification

### DIFF
--- a/lib/Authy/AuthyApi.php
+++ b/lib/Authy/AuthyApi.php
@@ -209,7 +209,7 @@ class AuthyApi
      */
     public function phoneVerificationStart($phone_number, $country_code,
                                            $via='sms', $code_length=4,
-                                           $locale=null)
+                                           $locale=null, $custom_message=null)
     {
 
         $query = [
@@ -221,6 +221,14 @@ class AuthyApi
 
         if ($locale != null) {
             $query["locale"] = $locale;
+        }
+
+        if ($custom_message != null) {
+            $query['custom_message'] = $custom_message;
+        }
+
+        if ($via == 'call' && $custom_message != null && $local == null) {
+            throw new AuthyFormatException('If the via method is set to call and you are using a custom_message the locale is required');
         }
 
         $resp = $this->rest->post("protected/json/phones/verification/start", array_merge(


### PR DESCRIPTION
This change will allow for passing a custom message with the phone verification. It will also check to ensure that if using the via "call" that locale is also set.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
