### PR TITLE
Update to Guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '5.6'
-  - '7.0'
-  - '7.1'
+  - '7.2'
+  - '7.3'
+  - '7.4'
 install: composer install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-cli
+FROM php:7.2-cli
 
 WORKDIR /home/authy-php
 SHELL ["/bin/bash", "-c"]
@@ -9,9 +9,4 @@ RUN  apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Composer (See: https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md)
-RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer -O - -q | php -- --install-dir=/bin --filename=composer
-
-# PHPUnit
-RUN wget https://phar.phpunit.de/phpunit-5.7.phar
-RUN chmod +x phpunit-5.7.phar
-RUN mv phpunit-5.7.phar /bin/phpunit
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --install-dir=/bin --filename=composer

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docker-deps:
 	docker run -v $(shell pwd):/home/authy-php authy-php composer update
 
 docker-test:
-	docker run -v $(shell pwd):/home/authy-php authy-php phpunit -v --colors=always
+	docker run -v $(shell pwd):/home/authy-php authy-php ./vendor/bin/phpunit -v --colors=always
 
 docker-shell:
 	docker run -it -v $(shell pwd):/home/authy-php authy-php bash

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2.5",
-        "guzzlehttp/guzzle": "~7.0"
+        "guzzlehttp/guzzle": "~6.0||~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "homepage": "https://github.com/twilio/authy-php",
     "license": "MIT",
     "require": {
-        "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "php": "^7.2.5",
+        "guzzlehttp/guzzle": "~7.0"
     },
     "require-dev": {
-        "EHER/PHPUnit": ">= 1.6"
+        "phpunit/phpunit": "^8.0"
     },
     "authors": [
         {

--- a/tests/Authy/ApiTest.php
+++ b/tests/Authy/ApiTest.php
@@ -6,15 +6,14 @@ use Authy\AuthyFormatException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Stream\Stream;
 
-class ApiTest extends \PHPUnit_Framework_TestCase
+class ApiTest extends \PHPUnit\Framework\TestCase
 {
     private $invalid_token;
     private $valid_token;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->invalid_token = '1234567';
         $this->valid_token = '0000000';

--- a/tests/Authy/TestCase.php
+++ b/tests/Authy/TestCase.php
@@ -1,5 +1,5 @@
 <?php
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
 }


### PR DESCRIPTION
This PR updates Guzzle to 7.x. In order to work with the 7.x Guzzle versions, we need to bump the minimum PHP requirement to 7.2, and also PHPUnit to 8.x.

All of this work is done in this PR, and the Docker scripts have been updated so that the test suite passes with these new dependency versions.

This should probably be tagged as a new major release due to the minimum PHP version increasing from 5.6.0 to 7.2.5.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
