### PR TITLE
Add QR Code method to 4.x release

### DIFF
--- a/lib/Authy/AuthyApi.php
+++ b/lib/Authy/AuthyApi.php
@@ -179,6 +179,25 @@ class AuthyApi
         $resp = $this->rest->get("protected/json/users/{$authy_id}/status", $this->default_options);
         return new AuthyResponse($resp);
     }
+    
+    /**
+     * Request QR code link.
+     *
+     * @param string $authy_id User's id stored in your database
+     * @param array  $opts     Array of options, for example: array("qr_size" => 300)
+     *
+     * @return AuthyResponse the server response
+     */
+    public function qrCode($authy_id, $opts = [])
+    {
+        $authy_id = urlencode($authy_id);
+        $resp = $this->rest->post("protected/json/users/{$authy_id}/secret", array_merge(
+            $this->default_options,
+            ['query' => $opts]
+        ));
+
+        return new AuthyResponse($resp);
+    }
 
     /**
      * Starts phone verification. (Sends token to user via sms or call).

--- a/tests/Authy/ApiTest.php
+++ b/tests/Authy/ApiTest.php
@@ -238,6 +238,28 @@ class ApiTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(true, $call->ok());
         $this->assertRegExp('/Call started/i', $call->message());
     }
+    
+    public function testQrCodeWithInvalidUser()
+    {
+        $mock_client = $this->mockClient([[404, '{"errors": {"message": "User not found."}}']]);
+        $call = $mock_client->qrCode(0, []);
+
+        $this->assertEquals(false, $call->ok());
+        $this->assertEquals("User not found.", $call->errors()->message);
+    }
+
+    public function testQrCodeWithValidUser()
+    {
+        $mock_client = $this->mockClient([
+            [200, '{ "user": { "id": 2 } }'],
+            [200, '{ "qr_code": "https://example.com/qr.png" }']
+        ]);
+        $user = $mock_client->registerUser('user@example.com', '305-456-2345', 1);
+        $call = $mock_client->qrCode($user->id(), []);
+
+        $this->assertEquals(true, $call->ok());
+        $this->assertNotNull($call->bodyvar('qr_code'));
+    }
 
     public function testDeleteUserWithInvalidUser()
     {


### PR DESCRIPTION
This PR adds the missing qrCode method to the 4.x release. It was accidentally removed due to it being merged directly into the 3.x release branch, and never getting into master.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
