### PR TITLE
Ignore dev files for package distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-/_tests
+/_tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-/_tests export-ignore
+/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/_tests
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+Dockerfile export-ignore
+Makefile export-ignore
+phpunit.xml.dist export-ignore
+verify-legacy-v1.md export-ignore


### PR DESCRIPTION
## Summary

A good idea is to exclude unneeded dev files from the final production zip archive file, which is also downloaded by composer (unless --prefer -source is specified).

Those files are actually only useful when working on the library itself.


If you are not familiar, further information about export-ignore can be found below:
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/
- https://madewithlove.be/gitattributes/

I hope it helps! 😊

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
